### PR TITLE
[Milestone 3] Profile Page Upgrade: GitHub Contributions, Streaks, and Badges

### DIFF
--- a/frontend/Mentor-mate/src/components/GithubActivity.jsx
+++ b/frontend/Mentor-mate/src/components/GithubActivity.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect } from "react";
+import GitHubCalendar from "react-github-calendar";
+
+export default function GithubActivity({ githubUrl }) {
+  const [activity, setActivity] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const username = githubUrl ? extractUsernameFromUrl(githubUrl) : null;
+
+  useEffect(() => {
+    if (!githubUrl) {
+      return;
+    }
+
+    const fetchGithubActivity = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `http://localhost:5000/api/github/activity`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${localStorage.getItem("token")}`,
+            },
+            body: JSON.stringify({ githubUrl }),
+          }
+        );
+
+        if (response.ok) {
+          const data = await response.json();
+          setActivity(data);
+        } else {
+          setError("Error fetching Github activity");
+        }
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchGithubActivity();
+  }, [githubUrl]);
+
+  function extractUsernameFromUrl(url) {
+    try {
+      const parsed = new URL(url);
+      const parts = parsed.pathname.split("/").filter(Boolean);
+      return parts[0];
+    } catch {
+      return null;
+    }
+  }
+
+  if (!githubUrl) {
+    return (
+      <div className="bg-white p-6 rounded-lg shadow-md mt-4">
+        <h3 className="text-lg font-semibold mb-3">Github Activity</h3>
+        <p>No Github URL Provided</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div>
+        <h3>Github Activity</h3>
+        <p>Loading Github data...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white p-6 rounded-lg shadow-md mt-4">
+        <h3 className="text-lg font-semibold mb-3">Github Activity</h3>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!activity) {
+    return (
+      <div className="bg-white p-6 rounded-lg shadow-md mt-4">
+        <h3 className="text-lg font-semibold mb-3">Github Activity</h3>
+        <p>No activity data available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-md">
+      <h3 className="text-lg font-semibold mb-3">Github Activity</h3>
+      <div className="space-y-2 text-gray-700">
+        <p>Contributions this month: {activity.contributionsThisMonth}</p>
+        <p>Top language: {activity.topLanguage}</p>
+        <p>Top project: {activity.topProject}</p>
+        <p>Commit streak: 🔥{activity.commitStreak} day(s)</p>
+        {activity.badges && activity.badges.length > 0 && (
+          <div>
+            <h4>Badges:</h4>
+            {activity.badges.map((badge, index) => (
+              <div key={index}>
+                <strong>{badge.name}</strong>: {badge.description}
+              </div>
+            ))}
+          </div>
+        )}
+        <div>
+          <h4>Contributions Chart</h4>
+          <GitHubCalendar username={username} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/Mentor-mate/src/main.jsx
+++ b/frontend/Mentor-mate/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.jsx";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/frontend/Mentor-mate/src/pages/Profile.jsx
+++ b/frontend/Mentor-mate/src/pages/Profile.jsx
@@ -1,0 +1,255 @@
+import React, { useState, useEffect } from "react";
+import Connections from "./Connections";
+import Navbar from "../components/Navbar";
+
+export default function Profile({ user, setUser }) {
+  const [isEditingBio, setIsEditingBio] = useState(false);
+  const [bio, setBio] = useState(user?.profile?.bio || "");
+  const [full_name, setFullName] = useState(user?.profile?.full_name || "");
+  const [profilePicUrl, setProfilePicUrl] = useState(
+    user?.profile?.profilePicUrl || ""
+  );
+  const [experiences, setExperiences] = useState(
+    user?.profile?.experiences || []
+  );
+  const [interests, setInterests] = useState(user?.profile?.interests || []);
+
+  useEffect(() => {
+    if (user && user.profile) {
+      setBio(user.profile.bio || "");
+      setFullName(user.profile.full_name || "");
+      setProfilePicUrl(user.profile.profilePicUrl || "");
+      setExperiences(user.profile.experiences || []);
+      setInterests(user.profile.interests || []);
+    }
+  }, [user]);
+
+  if (!user || !user.profile) {
+    return <div className="text-center mt-10 text-gray-600">Loading...</div>;
+  }
+
+  const handleSaveBio = async () => {
+    try {
+      const response = await fetch("http://localhost:5000/api/profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify({
+          full_name,
+          bio,
+          profilePicUrl,
+          interests,
+          experiences,
+        }),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setUser((prev) => ({ ...prev, profile: data.profile }));
+        setIsEditingBio(false);
+      } else {
+        alert("Failed to update bio");
+      }
+    } catch (err) {
+      alert(err);
+    }
+  };
+
+  return (
+    <>
+      <Navbar user={user} />
+      <div className="bg-gray-100 min-h-screen p-8">
+        <div className="max-w-7xl mx-auto">
+        {/* Profile Header */}
+        <div className="flex flex-col md:flex-row items-center bg-white rounded-lg shadow-md p-6 mb-8">
+          <img
+            src={user.profile.profilePicUrl}
+            alt="Profile"
+            className="w-32 h-32 rounded-full object-cover border-2 border-purple-500"
+          />
+          <div className="ml-0 md:ml-6 text-center md:text-left mt-4 md:mt-0">
+            <h2 className="text-2xl font-semibold">{user.profile.full_name}</h2>
+            <p className="text-gray-500">
+              {user.profile.role || "Role not added"}
+            </p>
+          </div>
+        </div>
+
+        {/* Skills and About */}
+        <div className="grid md:grid-cols-3 gap-6 mb-8">
+          <div className="bg-white p-6 rounded-lg shadow-md">
+            <h3 className="text-lg font-semibold mb-3">Skills</h3>
+            <ul className="space-y-2 text-gray-600">
+              {user.profile.interests.map((skill) => (
+                <li key={skill}>{skill}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="md:col-span-2 flex justify-between bg-white p-6 rounded-lg shadow-md">
+            <div>
+              <h3 className="text-lg font-semibold mb-3">About Me</h3>
+              <p className="text-gray-700 leading-relaxed">
+                {user.profile.bio || "No bio added"}
+              </p>
+            </div>
+            <button
+              className="bg-purple-500 text-white px-8 cursor-pointer h-10 rounded-md hover:bg-purple-600"
+              onClick={() => setIsEditingBio(true)}
+            >
+              Edit
+            </button>
+          </div>
+        </div>
+
+        {/* Experience */}
+        <div className="bg-white p-6 rounded-lg shadow-md mb-8">
+          <h3 className="text-lg font-semibold mb-4">Experience</h3>
+          {user.profile.experiences.map((experience, index) => (
+            <div key={index} className="mb-4">
+              <h4 className="font-medium">{experience}</h4>
+            </div>
+          ))}
+        </div>
+
+        {/* Modal to edit bio */}
+        {isEditingBio && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50  p-6 rounded-lg shadow-md mb-8">
+            <div className="bg-white shadow-lg w-full max-w-md p-6 relative">
+              <h3 className="text-lg font-semibold mb-4">Edit Bio</h3>
+              <h3>Name</h3>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="1"
+                value={full_name}
+                onChange={(e) => setFullName(e.target.value)}
+              ></textarea>
+              <h3>Bio</h3>
+
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="5"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+              ></textarea>
+              <h3>Skills</h3>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="1"
+                value={interests.join("\n")}
+                onChange={(e) => setInterests(e.target.value.split("\n"))}
+              ></textarea>
+              <h3>Profile Picture URL</h3>
+
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="5"
+                value={profilePicUrl}
+                onChange={(e) => setProfilePicUrl(e.target.value)}
+                placeholder="Set your profile picture URL here..."
+              ></textarea>
+              <h3>Experience</h3>
+
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="5"
+                value={experiences.join("\n")}
+                onChange={(e) => setExperiences(e.target.value.split("\n"))}
+                placeholder="Enter your experience here..."
+              ></textarea>
+              <button
+                onClick={handleSaveBio}
+                className="bg-purple-500 text-white px-4 py-2 rounded-md hover:bg-purple-600"
+              >
+                Save
+              </button>
+              <button
+                onClick={() => setIsEditingBio(false)}
+                className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 ml-4"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+
+          {/* Experience */}
+          <div className="bg-white p-6 rounded-lg shadow-md mb-8">
+            <h3 className="text-lg font-semibold mb-4">Experience</h3>
+            {user.profile.experiences.map((experience, index) => (
+              <div key={index} className="mb-4">
+                <h4 className="font-medium">{experience}</h4>
+              </div>
+            ))}
+          </div>
+
+          {/* Connections */}
+          <Connections />
+
+          <GithubActivity githubUrl={user.profile.githubUrl} />
+
+          {/* Modal to edit bio */}
+          {isEditingBio && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50  p-6 rounded-lg shadow-md mb-8">
+              <div className="bg-white shadow-lg w-full max-w-md p-6 relative">
+                <h3 className="text-lg font-semibold mb-4">Edit Bio</h3>
+                <h3>Name</h3>
+                <textarea
+                  className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                  rows="1"
+                  value={full_name}
+                  onChange={(e) => setFullName(e.target.value)}
+                ></textarea>
+                <h3>Bio</h3>
+
+                <textarea
+                  className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                  rows="5"
+                  value={bio}
+                  onChange={(e) => setBio(e.target.value)}
+                ></textarea>
+                <h3>Skills</h3>
+                <textarea
+                  className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                  rows="1"
+                  value={interests.join("\n")}
+                  onChange={(e) => setInterests(e.target.value.split("\n"))}
+                ></textarea>
+                <h3>Profile Picture URL</h3>
+
+                <textarea
+                  className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                  rows="5"
+                  value={profilePicUrl}
+                  onChange={(e) => setProfilePicUrl(e.target.value)}
+                  placeholder="Set your profile picture URL here..."
+                ></textarea>
+                <h3>Experience</h3>
+
+                <textarea
+                  className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                  rows="5"
+                  value={experiences.join("\n")}
+                  onChange={(e) => setExperiences(e.target.value.split("\n"))}
+                  placeholder="Enter your experience here..."
+                ></textarea>
+                <button
+                  onClick={handleSaveBio}
+                  className="bg-purple-500 text-white px-4 py-2 rounded-md hover:bg-purple-600"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => setIsEditingBio(false)}
+                  className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 ml-4"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/Mentor-mate/src/pages/UserProfile.jsx
+++ b/frontend/Mentor-mate/src/pages/UserProfile.jsx
@@ -1,0 +1,240 @@
+import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import Navbar from "../components/Navbar";
+
+import GithubActivity from "../components/GithubActivity";
+import Connections from "./Connections";
+
+export default function UserProfile() {
+  const { userId } = useParams();
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [isEditingBio, setIsEditingBio] = useState(false);
+  const [bio, setBio] = useState("");
+  const [full_name, setFullName] = useState("");
+  const [profilePicUrl, setProfilePicUrl] = useState("");
+  const [experiences, setExperiences] = useState([]);
+  const [interests, setInterests] = useState([]);
+
+  // Check if this is the user's own profile (no userId param means own profile)
+  const isOwnProfile = !userId;
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        let response;
+        if (isOwnProfile) {
+          // Fetch current user's profile
+          response = await fetch("http://localhost:5000/api/users/me", {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem("token")}`,
+            },
+          });
+        } else {
+          // Fetch specific user's profile
+          response = await fetch(`http://localhost:5000/api/users/${userId}`, {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem("token")}`,
+            },
+          });
+        }
+
+        if (response.ok) {
+          const data = await response.json();
+          setUser(data);
+          // Set editing states for own profile
+          if (isOwnProfile && data.profile) {
+            setBio(data.profile.bio || "");
+            setFullName(data.profile.full_name || "");
+            setProfilePicUrl(data.profile.profilePicUrl || "");
+            setExperiences(data.profile.experiences || []);
+            setInterests(data.profile.interests || []);
+          }
+        } else {
+          alert("User not found");
+        }
+      } catch (error) {
+        alert("Error fetching user");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchUser();
+  }, [userId, isOwnProfile]);
+
+  const handleSaveBio = async () => {
+    try {
+      const response = await fetch("http://localhost:5000/api/profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify({
+          full_name,
+          bio,
+          profilePicUrl,
+          interests,
+          experiences,
+        }),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setUser((prev) => ({ ...prev, profile: data.profile }));
+        setIsEditingBio(false);
+      } else {
+        alert("Failed to update profile");
+      }
+    } catch (err) {
+      alert("Error updating profile");
+    }
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!user || !user.profile) {
+    return <div>User not found</div>;
+  }
+
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <div className="flex flex-col md:flex-row items-center bg-white rounded-lg shadow-md p-6 mb-8">
+          <img
+            src={user.profile.profilePicUrl}
+            alt="Profile"
+            className="w-32 h-32 rounded-full object-cover border-2 border-purple-500"
+          ></img>
+          <div className="ml-0 md:ml-6 text-center md:text-left mt-4 md:mt-0">
+            <h2 className="text-2xl font-semibold">{user.profile.full_name}</h2>
+            <p className="text-gray-500">
+              {user.profile.role || "Role not added"}
+            </p>
+          </div>
+        </div>
+
+        {/* Skills and About */}
+        <div className="flex flex-col md:flex-row gap-6 mb-8">
+          <div className="bg-white p-6 rounded-lg shadow-md md:w-1/3">
+            <h3 className="text-lg font-semibold mb-4">Skills</h3>
+            <ul>
+              {user.profile.interests.map((skill) => (
+                <li key={skill}>{skill}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="bg-white p-6 rounded-lg shadow-md md:w-2/3">
+            <div className="flex justify-between items-start">
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold mb-3">About Me</h3>
+                <p>{user.profile.bio || "No bio added"}</p>
+              </div>
+              {isOwnProfile && (
+                <button
+                  className="bg-purple-500 text-white px-4 py-2 rounded-md hover:bg-purple-600"
+                  onClick={() => setIsEditingBio(true)}
+                >
+                  Edit
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Experience */}
+        <div className="bg-white p-6 rounded-lg shadow-md mb-8">
+          <h3 className="text-lg font-semibold mb-4">Experience</h3>
+          {user.profile.experiences.map((experience, index) => (
+            <div key={index} className="mb-4">
+              <h4 className="font-medium">{experience}</h4>
+            </div>
+          ))}
+        </div>
+
+        {/* Github Activity */}
+        <GithubActivity githubUrl={user.profile.githubUrl} />
+
+        {/* Connections */}
+        <Connections targetUser={user} />
+
+        {/* Modal to edit bio - only show for own profile */}
+        {isEditingBio && isOwnProfile && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6">
+            <div className="bg-white shadow-lg w-full max-w-md p-6 rounded-lg">
+              <h3 className="text-lg font-semibold mb-4">Edit Profile</h3>
+
+              <h4 className="font-medium mb-2">Name</h4>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="1"
+                value={full_name}
+                onChange={(e) => setFullName(e.target.value)}
+              />
+
+              <h4 className="font-medium mb-2">Bio</h4>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="5"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+              />
+
+              <h4 className="font-medium mb-2">Skills</h4>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="3"
+                value={interests.join("\n")}
+                onChange={(e) =>
+                  setInterests(
+                    e.target.value.split("\n").filter((skill) => skill.trim())
+                  )
+                }
+                placeholder="Enter each skill on a new line"
+              />
+
+              <h4 className="font-medium mb-2">Profile Picture URL</h4>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="2"
+                value={profilePicUrl}
+                onChange={(e) => setProfilePicUrl(e.target.value)}
+                placeholder="Enter profile picture URL"
+              />
+
+              <h4 className="font-medium mb-2">Experience</h4>
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2 mb-4"
+                rows="5"
+                value={experiences.join("\n")}
+                onChange={(e) =>
+                  setExperiences(
+                    e.target.value.split("\n").filter((exp) => exp.trim())
+                  )
+                }
+                placeholder="Enter each experience on a new line"
+              />
+
+              <div className="flex gap-2">
+                <button
+                  onClick={handleSaveBio}
+                  className="bg-purple-500 text-white px-4 py-2 rounded-md hover:bg-purple-600"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => setIsEditingBio(false)}
+                  className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### What does this PR include?
Better separation of concerns between viewing and editing state
Profile page refactor (Profile.jsx & UserProfile.jsx)
Integrated GithubActivity component into both personal and public profile views
Improved layout and organization of bio, skills, experiences, and GitHub activity
Editable fields now include name, bio, skills, profile picture URL, and experience

### What is intentionally left out and will be done in a later PR?
Get commit streak from public repos in organizations that the user belongs to

### Milestones / Related Work
[3.1 Profile page + Github REST API Integration – Completed](https://docs.google.com/document/d/1WRUSes2pROT1itX7Xp8pU8PhU4zVYKMPfSw8eaQ3TdE/edit?tab=t.0#bookmark=id.klm8z55v9ofj)
[3.2 Users can customize their profile page – Completed](https://docs.google.com/document/d/1WRUSes2pROT1itX7Xp8pU8PhU4zVYKMPfSw8eaQ3TdE/edit?tab=t.0#bookmark=id.klm8z55v9ofj)

### Resources and References
[GitHub REST API v3](https://docs.github.com/en/rest/users?apiVersion=2022-11-28)

### Test Plan
How was this tested?
Manually tested in the dev environment
Loom video - [Click Here](https://www.loom.com/share/f91abbbf50fa4ef9a6ba28f2f5dbc50c?sid=75217a1c-edcd-4dbd-821a-c6f04e01d3a1)